### PR TITLE
Fix(DAO): Usar funciones de fecha compatibles con MySQL

### DIFF
--- a/TransaccionDAO.java
+++ b/TransaccionDAO.java
@@ -174,13 +174,13 @@ public class TransaccionDAO {
 
     public double obtenerTotalIngresosDelMes(int mes, int año) throws SQLException {
         LOGGER.log(Level.INFO, "DAO: Intentando obtener total de ingresos para Mes: {0}, Año: {1}", new Object[]{mes, año});
-        String sql = "SELECT COALESCE(SUM(monto), 0) as total FROM transacciones WHERE tipo = 'INGRESO' AND strftime('%m', fecha) = ? AND strftime('%Y', fecha) = ?";
+        String sql = "SELECT COALESCE(SUM(monto), 0) as total FROM transacciones WHERE tipo = 'INGRESO' AND MONTH(fecha) = ? AND YEAR(fecha) = ?";
         double totalIngresos = 0.0;
 
         try (Connection conn = DatabaseConnection.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
-            stmt.setString(1, String.format("%02d", mes));
-            stmt.setString(2, String.valueOf(año));
+            stmt.setInt(1, mes);
+            stmt.setInt(2, año);
             try (ResultSet rs = stmt.executeQuery()) {
                 if (rs.next()) {
                     totalIngresos = rs.getDouble("total");
@@ -196,13 +196,13 @@ public class TransaccionDAO {
 
     public double obtenerTotalGastosDelMes(int mes, int año) throws SQLException {
         LOGGER.log(Level.INFO, "DAO: Intentando obtener total de gastos para Mes: {0}, Año: {1}", new Object[]{mes, año});
-        String sql = "SELECT COALESCE(SUM(monto), 0) as total FROM transacciones WHERE tipo = 'GASTO' AND strftime('%m', fecha) = ? AND strftime('%Y', fecha) = ?";
+        String sql = "SELECT COALESCE(SUM(monto), 0) as total FROM transacciones WHERE tipo = 'GASTO' AND MONTH(fecha) = ? AND YEAR(fecha) = ?";
         double totalGastos = 0.0;
 
         try (Connection conn = DatabaseConnection.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
-            stmt.setString(1, String.format("%02d", mes));
-            stmt.setString(2, String.valueOf(año));
+            stmt.setInt(1, mes);
+            stmt.setInt(2, año);
             try (ResultSet rs = stmt.executeQuery()) {
                 if (rs.next()) {
                     totalGastos = rs.getDouble("total");
@@ -219,12 +219,12 @@ public class TransaccionDAO {
     public Map<String, Double> obtenerGastosPorCategoriaDelMes(int mes, int año) throws SQLException {
         LOGGER.log(Level.INFO, "DAO: Intentando obtener gastos por categoría para Mes: {0}, Año: {1}", new Object[]{mes, año});
         Map<String, Double> gastosPorCategoria = new HashMap<>();
-        String sql = "SELECT categoria, SUM(monto) as total FROM transacciones WHERE tipo = 'GASTO' AND strftime('%m', fecha) = ? AND strftime('%Y', fecha) = ? GROUP BY categoria";
+        String sql = "SELECT categoria, SUM(monto) as total FROM transacciones WHERE tipo = 'GASTO' AND MONTH(fecha) = ? AND YEAR(fecha) = ? GROUP BY categoria";
 
         try (Connection conn = DatabaseConnection.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
-            stmt.setString(1, String.format("%02d", mes));
-            stmt.setString(2, String.valueOf(año));
+            stmt.setInt(1, mes);
+            stmt.setInt(2, año);
             try (ResultSet rs = stmt.executeQuery()) {
                 int count = 0;
                 while (rs.next()) {


### PR DESCRIPTION
- Reemplazadas las funciones strftime por MONTH() y YEAR() en TransaccionDAO.java para compatibilidad con MySQL.
- Ajustados los PreparedStatement para pasar mes y año como enteros.