### PR TITLE
Fix: Asegurar actualización de gasto_actual en presupuestos al regist…

### DIFF
--- a/GestorPresupuestos.java
+++ b/GestorPresupuestos.java
@@ -63,17 +63,19 @@ public class GestorPresupuestos {
         }
     }
 
-    public void registrarGastoEnPresupuesto(String categoria, double monto) {
+    public boolean registrarGastoEnPresupuesto(String categoria, double monto) {
         LOGGER.log(Level.INFO, "Gestor: Intentando registrar gasto de {0} en categoría ''{1}'' en presupuesto actual.", new Object[]{monto, categoria});
         if (categoria == null || categoria.trim().isEmpty()) {
             LOGGER.warning("Gestor: Intento de registrar gasto con categoría null o vacía.");
-            return;
+            return false; // Fallo por validación
         }
         try {
             presupuestoDAO.registrarGastoEnPresupuesto(categoria, monto);
             LOGGER.log(Level.INFO, "Gestor: Registro de gasto para categoría ''{0}'' pasado a DAO.", categoria);
+            return true; // Indicar éxito
         } catch (SQLException e) {
             LOGGER.log(Level.SEVERE, "Gestor: Error SQL al registrar gasto en categoría " + categoria, e);
+            return false; // Indicar fallo
         }
     }
 

--- a/InterfazFinanciera.java
+++ b/InterfazFinanciera.java
@@ -586,8 +586,22 @@ public class InterfazFinanciera extends JFrame {
             boolean exitoOperacion;
             if (tipo.equals("INGRESO")) {
                 exitoOperacion = sistema.registrarIngreso(descripcion, monto, categoria);
-            } else {
+            } else { // GASTO
                 exitoOperacion = sistema.registrarGasto(descripcion, monto, categoria);
+                if (exitoOperacion) {
+                    // Si el gasto se registró correctamente, también actualizamos el presupuesto
+                    LOGGER.info("Gasto registrado, intentando actualizar el gasto en presupuesto para categoría: " + categoria + ", Monto: " + monto);
+                    boolean exitoPresupuesto = sistema.registrarGastoEnPresupuesto(categoria, monto);
+                    if (exitoPresupuesto) {
+                        LOGGER.info("Gasto en presupuesto actualizado exitosamente para categoría: " + categoria);
+                    } else {
+                        // No se considera un error fatal para el registro de la transacción en sí,
+                        // pero se loguea. Podría ser que no haya presupuesto o categoría definida.
+                        LOGGER.warning("No se pudo actualizar el gasto en el presupuesto para la categoría: " + categoria + ". Puede que no exista un presupuesto o categoría para el mes actual.");
+                        // Opcionalmente, informar al usuario de esto, pero puede ser mucho detalle.
+                        // JOptionPane.showMessageDialog(this, "Gasto registrado, pero no se pudo actualizar en el presupuesto (categoría o presupuesto de mes actual podría no existir).", "Advertencia Presupuesto", JOptionPane.WARNING_MESSAGE);
+                    }
+                }
             }
             LOGGER.info("Resultado de fachada para registrar " + tipo + ": " + exitoOperacion);
 
@@ -596,6 +610,7 @@ public class InterfazFinanciera extends JFrame {
                 txtMonto.setText("");
                 txtCategoria.setText("");
                 actualizarTablaTransacciones();
+                actualizarTablaPresupuestos(); // Asegurar que la tabla de presupuestos también se actualice
                 actualizarResumen();
                 JOptionPane.showMessageDialog(this, "Transacción registrada exitosamente.");
                 LOGGER.info("Transacción registrada y UI actualizada.");

--- a/SistemaFinancieroFacade.java
+++ b/SistemaFinancieroFacade.java
@@ -157,15 +157,14 @@ public class SistemaFinancieroFacade {
 
     public boolean registrarGastoEnPresupuesto(String categoria, double monto) {
         LOGGER.log(Level.INFO, "Facade: Registrar Gasto en Presupuesto - Cat: {0}, Monto: {1}", new Object[]{categoria, monto});
-        // Similar a crearPresupuesto, GestorPresupuestos.registrarGastoEnPresupuesto no devuelve boolean.
-        try {
-            gestorPresupuestos.registrarGastoEnPresupuesto(categoria, monto);
-            LOGGER.info("Facade: Gasto en presupuesto pasado a GestorPresupuestos.");
-            return true;
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Facade: Error inesperado al registrar gasto en presupuesto", e);
-            return false;
+        boolean exito = gestorPresupuestos.registrarGastoEnPresupuesto(categoria, monto);
+        if (exito) {
+            LOGGER.info("Facade: Gasto en presupuesto procesado por GestorPresupuestos con éxito.");
+        } else {
+            LOGGER.warning("Facade: GestorPresupuestos reportó un fallo al registrar gasto en presupuesto.");
+            // El error específico (SQLException o validación) ya fue logueado por el Gestor.
         }
+        return exito;
     }
 
     public boolean agregarCategoriaAPresupuesto(String nombrePresupuesto, int mes, int año, String categoria, double limite) {


### PR DESCRIPTION
…rar transacción

- Modificado InterfazFinanciera.agregarTransaccion para llamar a sistema.registrarGastoEnPresupuesto después de registrar un gasto.
- Ajustada la firma y lógica de registrarGastoEnPresupuesto en GestorPresupuestos y SistemaFinancieroFacade para devolver boolean y manejar el flujo.
- Esto asegura que el campo gasto_actual en la tabla categorias_presupuesto se actualice en la BD, y la UI refleje este cambio.